### PR TITLE
add redis go and cilium cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN apk update && apk add \
   grpcurl \
   vim \
   tmux \
-  aws-cli
+  aws-cli \
+  redis \
+  go 
+
+## Cilium 
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM alpine:3.18.2
-
+FROM alpine:3.20.2
 
 RUN apk update && apk add \
   postgresql-client \
   curl \
+  tar \
+  coreutils \
   nmap \
   netcat-openbsd \
   tcpdump \
@@ -20,5 +21,13 @@ RUN apk update && apk add \
   go 
 
 ## Cilium 
+RUN CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt) && \
+    CLI_ARCH=amd64 && \
+    if [ "$(uname -m)" = "aarch64" ]; then CLI_ARCH=arm64; fi && \
+    curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz && \
+    curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz.sha256sum && \
+    sha256sum -c cilium-linux-${CLI_ARCH}.tar.gz.sha256sum && \
+    tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin && \
+    rm cilium-linux-${CLI_ARCH}.tar.gz cilium-linux-${CLI_ARCH}.tar.gz.sha256sum
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Adding `go`, `redis` and `cilium cli`  ([cilium install docs](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/))